### PR TITLE
Data update/use esa new release 2022 data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import DataAttribution from './components/dataAttribution/DataAttribution';
 
 preventDefaultDragDropBehaviour();
 
-export const availableYears = [2010, 2017, 2018, 2019, 2020];
+export const availableYears = [2007, 2010, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022];
 
 function App() {
   const [agbData, setAgbData] = useState<(CedaData | null)[]>(availableYears.map(() => null));

--- a/src/components/dropZone/DropZone.tsx
+++ b/src/components/dropZone/DropZone.tsx
@@ -34,16 +34,20 @@ const DropZone = ({setAgbData, setPolygon, setXY, setRowsStatus, setSelectedYear
     }
 
     const item = items[0];
-    if (item.kind !== "file" || !item.type.includes('kml')) {
-      setFileError('File format must be .kml');
-      console.log(item.kind);
-      console.log(item.type);
+    if (item.kind !== "file") {
+      setFileError('Please drop a file');
       return;
     }
 
     const file = item.getAsFile();
     if (file == null) {
       setFileError('Unexpected error occurred while loading file');
+      return;
+    }
+
+    // Check if the file is a KML file by extension
+    if (!file.name.toLowerCase().endsWith('.kml')) {
+      setFileError('File format must be .kml');
       return;
     }
 

--- a/src/scripts/CEDA/CedaHttpClient.ts
+++ b/src/scripts/CEDA/CedaHttpClient.ts
@@ -3,8 +3,8 @@ import { getSecondsElapsed } from "../TimeUtils";
 const retryTimeoutSeconds = 1;
 
 export const callCedaEndpoint = async (year: number, latIndexEnd: number, latIndexStart: number, lonIndexStart: number, lonIndexEnd: number, ): Promise<string | null> => {
-  const url ="https://dap.ceda.ac.uk/thredds/dodsC/neodc/esacci/biomass/data/agb/maps/v4.0/netcdf/" + 
-  `ESACCI-BIOMASS-L4-AGB-MERGED-100m-${year}-fv4.0.nc.ascii` + 
+  const url ="https://dap.ceda.ac.uk/thredds/dodsC/neodc/esacci/biomass/data/agb/maps/v6.0/netcdf/" + 
+  `ESACCI-BIOMASS-L4-AGB-MERGED-100m-${year}-fv6.0.nc.ascii` + 
   `?agb[0:1:0][${latIndexStart}:1:${latIndexEnd}][${lonIndexStart}:1:${lonIndexEnd}]`;
 
   const startTime = new Date();


### PR DESCRIPTION
Previously, we only had CEDA ESA data for years up to 2020. 

Now that ESA has released 2022 data, we want to switch to the latest dataset.

This PR also fixes a weird file drop zone bug that we notice, where for some reason the file's type is identified incorrectly.

<img width="731" height="937" alt="image" src="https://github.com/user-attachments/assets/08ae01dd-63e3-486d-aa9d-c0a6f6e0b730" />
